### PR TITLE
Unable to install (Updated the distribution version)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,7 +87,8 @@ rm -rf ${download_dir}
 mkdir -p ${download_dir}
 download_file=${download_dir}/${asset_filename}
 
-download_url="https://github.com/theodi/csvlint.sh/releases/download/${cli_version}/${tar_filename}.tar.gz"
+#download_url="https://github.com/theodi/csvlint.sh/releases/download/${cli_version}/${tar_filename}.tar.gz"
+download_url="https://github.com/theodi/csvlint.sh/releases/download/0.3.2/csvlint-0.3.2-osx.tar.gz"
 
 echo "Downloading v${cli_version}..."
 curl -k -L -H "Accept: application/octet-stream" $download_url -o ${download_file}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,7 +87,7 @@ rm -rf ${download_dir}
 mkdir -p ${download_dir}
 download_file=${download_dir}/${asset_filename}
 
-download_url="https://github.com/theodi/csvlint.sh/releases/download/v${cli_version}/${tar_filename}.tar.gz"
+download_url="https://github.com/theodi/csvlint.sh/releases/download/${cli_version}/${tar_filename}.tar.gz"
 
 echo "Downloading v${cli_version}..."
 curl -k -L -H "Accept: application/octet-stream" $download_url -o ${download_file}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -66,7 +66,7 @@ if [[ $EUID -eq 0 ]]; then
   update_profile "/etc/bash.bashrc"
 fi
 
-cli_version=0.3.1
+cli_version=0.3.2
 tar_filename="csvlint-${cli_version}-${download_platform}"
 asset_filename="csvlint.tgz"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,8 +87,7 @@ rm -rf ${download_dir}
 mkdir -p ${download_dir}
 download_file=${download_dir}/${asset_filename}
 
-#download_url="https://github.com/theodi/csvlint.sh/releases/download/${cli_version}/${tar_filename}.tar.gz"
-download_url="https://github.com/theodi/csvlint.sh/releases/download/0.3.2/csvlint-0.3.2-osx.tar.gz"
+download_url="https://github.com/theodi/csvlint.sh/releases/download/${cli_version}/${tar_filename}.tar.gz"
 
 echo "Downloading v${cli_version}..."
 curl -k -L -H "Accept: application/octet-stream" $download_url -o ${download_file}


### PR DESCRIPTION
I was unable to download the tar file. When I did a digging, I found the download url wasn't generating correctly. The installation script is still using `cli_version=0.3.1`.

Made few changes to fix this =)